### PR TITLE
User rating endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,7 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+.idea/
+.idea/marketnest.iml
+.idea/misc.xml

--- a/.idea/marketnest.iml
+++ b/.idea/marketnest.iml
@@ -5,7 +5,7 @@
       <excludeFolder url="file://$MODULE_DIR$/.venv" />
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.13 (marketnest) (3)" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.13 (marketnest)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,5 +3,5 @@
   <component name="Black">
     <option name="sdkName" value="Python 3.13" />
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.13 (marketnest) (3)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.13 (marketnest)" project-jdk-type="Python SDK" />
 </project>

--- a/app/api/user_ratings.py
+++ b/app/api/user_ratings.py
@@ -1,0 +1,63 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.orm import Session
+from app.db.database import get_db
+from app.core.security import get_current_user
+from app.models.user import User
+from app.models.user_rating import UserRating
+from app.schemas.user_rating import UserRatingCreate, UserRatingResponse
+
+router = APIRouter()
+
+@router.post(
+    path="/",
+    summary="User Ratings",
+    response_model=UserRatingResponse,
+    status_code=status.HTTP_201_CREATED,
+    description="Create user rating",
+)
+async def create_user_rating(
+        user_rating: UserRatingCreate,
+        current_user: User = Depends(get_current_user),
+        db: Session = Depends(get_db)):
+
+    db_user_rating = UserRating(
+        reviewer_id=current_user.id,
+        reviewed_user_id=user_rating.reviewed_user_id,
+        advertisement_id=user_rating.advertisement_id,
+        rating=user_rating.rating,
+        comment=user_rating.comment
+
+    )
+
+    db.add(db_user_rating)
+    db.commit()
+    db.refresh(db_user_rating)
+    return db_user_rating
+
+@router.get(
+    "{reviewed_id}",
+    summary="User Ratings",
+    description="Get all reviews about a User",
+    response_model=List[UserRatingResponse],
+    status_code=status.HTTP_200_OK
+    )
+async def get_all_ratings_about_user(
+    reviewed_id: int,
+    db: Session = Depends(get_db)
+    ):
+    return db.query(UserRating).filter(UserRating.reviewed_user_id == reviewed_id).all()
+
+@router.get(
+    "/reviewer/{reviewer_id}",
+    summary="User Ratings",
+    description="Get all reviews made by a User",
+    response_model=List[UserRatingResponse],
+    status_code=status.HTTP_200_OK
+    )
+async def get_all_ratings_made_by_user(
+    reviewer_id: int,
+    db: Session = Depends(get_db)
+    ):
+    return db.query(UserRating).filter(UserRating.reviewer_id == reviewer_id).all()

--- a/app/models/advertisement.py
+++ b/app/models/advertisement.py
@@ -13,3 +13,4 @@ class Advertisement(Base):
     created_at = Column(DateTime, default=datetime.now)
     updated_at = Column(DateTime, default=datetime.now)
     owner = relationship("User", back_populates="advertisements")
+    reviews = relationship("UserRating", back_populates="advertisement")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -12,3 +12,6 @@ class User(Base):
     created_at = Column(DateTime, default=datetime.now)
     updated_at = Column(DateTime, default=datetime.now)
     advertisements = relationship("Advertisement", back_populates="owner")
+
+    reviews_given = relationship("UserRating", foreign_keys="UserRating.reviewer_id", back_populates="reviewer")
+    reviews_received = relationship("UserRating", foreign_keys="UserRating.reviewed_user_id", back_populates="reviewed_user")

--- a/app/models/user_rating.py
+++ b/app/models/user_rating.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+
+from sqlalchemy import Column, Integer, ForeignKey, DateTime, Float, String
+from sqlalchemy.orm import relationship
+
+from app.db.database import Base
+
+
+
+class UserRating(Base):
+    __tablename__ = "user_ratings"
+    id = Column(Integer, primary_key=True)
+    reviewer_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    reviewed_user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    advertisement_id = Column(Integer, ForeignKey("advertisements.id"), nullable=False)
+    rating = Column(Integer, nullable=False)
+    comment = Column(String, nullable=False)
+    created_at = Column(DateTime, default=datetime.now)
+    reviewer = relationship("User", foreign_keys=[reviewer_id], back_populates="reviews_given")
+    reviewed_user = relationship("User", foreign_keys=[reviewed_user_id], back_populates="reviews_received")
+    advertisement = relationship("Advertisement", back_populates="reviews")

--- a/app/schemas/user_rating.py
+++ b/app/schemas/user_rating.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class UserRatingBase(BaseModel):
+
+    reviewed_user_id: int
+    advertisement_id: int
+    rating: int
+    comment: str
+
+class UserRatingCreate(UserRatingBase):
+    pass
+
+class UserRatingResponse(BaseModel):
+    id: int
+    reviewer_id: int
+    advertisement_id: int
+    rating: int
+    comment: str
+    created_at: datetime
+    model_config = ConfigDict(from_attributes=True)
+
+

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from app.api import auth, users, advertisements, user_ratings
+from app.api import auth, users, advertisements, ratings
 from app.db.database import Base, engine
 
 app = FastAPI(title="MarketNest API")
@@ -10,4 +10,4 @@ app.include_router(auth.router, prefix="/auth", tags=['auth'])
 app.include_router(users.router, prefix="/users", tags=['users'])
 app.include_router(advertisements.router, prefix='/advertisements', tags=['advertisements'])
 
-app.include_router(user_ratings.router, prefix='/user_ratings', tags=['users_ratings'])
+app.include_router(ratings.router, prefix="/ratings", tags=["ratings"])

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from app.api import auth, users, advertisements
+from app.api import auth, users, advertisements, user_ratings
 from app.db.database import Base, engine
 
 app = FastAPI(title="MarketNest API")
@@ -9,3 +9,5 @@ Base.metadata.create_all(bind=engine)
 app.include_router(auth.router, prefix="/auth", tags=['auth'])
 app.include_router(users.router, prefix="/users", tags=['users'])
 app.include_router(advertisements.router, prefix='/advertisements', tags=['advertisements'])
+
+app.include_router(user_ratings.router, prefix='/user_ratings', tags=['users_ratings'])


### PR DESCRIPTION
Changes introduced in this PR:

Moved rating-related functionality from user_ratings.py to a new ratings.py module for better separation of concerns.

Updated router include to use prefix="/ratings" and tags=["ratings"].

Added business logic validations:

Prevent users from rating themselves.

Prevent duplicate ratings (only one rating allowed per reviewer–reviewed user pair).

Refactored endpoints to avoid path conflicts:

GET /ratings/about/{user_id} → fetch all ratings about a user.

GET /ratings/by/{user_id} → fetch all ratings made by a user.