### PR TITLE
feat(messages): implement user messaging system

### DIFF
--- a/app/api/messages.py
+++ b/app/api/messages.py
@@ -1,0 +1,62 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from sqlalchemy import or_, and_
+from app.auth.oauth2 import get_current_user
+from app.db.database import get_db
+from app.models.message import Message
+from app.models.user import User
+from app.schemas.message import MessageCreate, MessageResponse
+from typing import List
+
+router = APIRouter()
+
+
+@router.post("/",
+    response_model=MessageResponse,
+    summary="Send Message",
+    description="Send a message to another user. Can be related to a specific advertisement or general conversation."
+)
+async def send_message(
+        message: MessageCreate,
+        current_user: User = Depends(get_current_user),
+        db: Session = Depends(get_db)
+):
+    receiver = db.query(User).filter(User.id == message.receiver_id).first()
+    if not receiver:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Receiver not found"
+        )
+
+    db_message = Message(
+        sender_id=current_user.id,
+        receiver_id=message.receiver_id,
+        advertisement_id=message.advertisement_id,
+        content=message.content
+    )
+
+    db.add(db_message)
+    db.commit()
+    db.refresh(db_message)
+
+    return db_message
+
+
+@router.get("/conversation/{user_id}",
+    response_model=List[MessageResponse],
+    summary="Get Conversation",
+    description="Retrieve all messages between current user and specified user, ordered chronologically."
+)
+async def get_conversation(
+        user_id: int,
+        current_user: User = Depends(get_current_user),
+        db: Session = Depends(get_db)
+):
+    messages = db.query(Message).filter(
+        or_(
+            and_(Message.sender_id == current_user.id, Message.receiver_id == user_id),
+            and_(Message.sender_id == user_id, Message.receiver_id == current_user.id)
+        )
+    ).order_by(Message.created_at.asc()).all()
+
+    return messages

--- a/app/models/message.py
+++ b/app/models/message.py
@@ -1,0 +1,19 @@
+from app.db.database import Base
+from sqlalchemy import Column, Integer, ForeignKey, DateTime, Text
+from datetime import datetime
+from sqlalchemy.orm import relationship
+
+
+class Message(Base):
+    __tablename__ = "messages"
+
+    id = Column(Integer, primary_key=True, index=True)
+    sender_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    receiver_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    advertisement_id = Column(Integer, ForeignKey("advertisements.id"), nullable=True)
+    content = Column(Text, nullable=False)
+    created_at = Column(DateTime, default=datetime.now)
+
+    sender = relationship("User", foreign_keys=[sender_id])
+    receiver = relationship("User", foreign_keys=[receiver_id])
+    advertisement = relationship("Advertisement")

--- a/app/schemas/message.py
+++ b/app/schemas/message.py
@@ -1,11 +1,11 @@
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from datetime import datetime
 from typing import Optional
 
 class MessageBase(BaseModel):
-    content: str
-    receiver_id: int
-    advertisement_id: Optional[int] = None
+    content: str = Field(..., min_length=1, max_length=1000)
+    receiver_id: int = Field(..., gt=0)
+    advertisement_id: Optional[int] = Field(None, gt=0)
 
 class MessageCreate(MessageBase):
     pass
@@ -20,8 +20,8 @@ class MessageResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 class ConversationResponse(BaseModel):
-    user_id: int
-    username: str
-    last_message: str
+    user_id: int = Field(..., gt=0)
+    username: str = Field(..., min_length=1)
+    last_message: str = Field(..., min_length=1)
     last_message_time: datetime
-    unread_count: int = 0
+    unread_count: int = Field(default=0, ge=0)

--- a/app/schemas/message.py
+++ b/app/schemas/message.py
@@ -1,0 +1,27 @@
+from pydantic import BaseModel, ConfigDict
+from datetime import datetime
+from typing import Optional
+
+class MessageBase(BaseModel):
+    content: str
+    receiver_id: int
+    advertisement_id: Optional[int] = None
+
+class MessageCreate(MessageBase):
+    pass
+
+class MessageResponse(BaseModel):
+    id: int
+    sender_id: int
+    receiver_id: int
+    advertisement_id: Optional[int]
+    content: str
+    created_at: datetime
+    model_config = ConfigDict(from_attributes=True)
+
+class ConversationResponse(BaseModel):
+    user_id: int
+    username: str
+    last_message: str
+    last_message_time: datetime
+    unread_count: int = 0

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from app.api import users, advertisements, ratings, categories
+from app.api import users, advertisements, ratings, categories, messages
 from app.auth import auth
 from app.db.database import Base, engine
 
@@ -10,5 +10,7 @@ app.include_router(users.router, prefix="/users", tags=['users'])
 app.include_router(advertisements.router, prefix='/advertisements', tags=['advertisements'])
 app.include_router(categories.router, prefix='/categories', tags=['categories'])
 app.include_router(ratings.router, prefix="/ratings", tags=["ratings"])
+app.include_router(messages.router, prefix="/messages", tags=["messages"])
+
 
 Base.metadata.create_all(bind=engine)

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,0 +1,130 @@
+from fastapi import status
+
+
+def test_send_message_success(client, auth_token):
+    client.post("/users/register", json={
+        "username": "receiver_user",
+        "email": "receiver@example.com",
+        "password": "password123"
+    })
+
+    response = client.post("/messages/",
+                           headers={"Authorization": f"Bearer {auth_token}"},
+                           json={
+                               "receiver_id": 2,
+                               "content": "Hello, interested in your item!",
+                               "advertisement_id": None
+                           })
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["sender_id"] == 1
+    assert data["receiver_id"] == 2
+    assert data["content"] == "Hello, interested in your item!"
+    assert "id" in data
+    assert "created_at" in data
+
+
+def test_send_message_with_advertisement(client, auth_token):
+    client.post("/users/register", json={
+        "username": "seller",
+        "email": "seller@example.com",
+        "password": "password123"
+    })
+
+    ad_response = client.post("/advertisements/",
+                              headers={"Authorization": f"Bearer {auth_token}"},
+                              json={
+                                  "title": "iPhone for sale",
+                                  "description": "Good condition",
+                                  "price": 500.0,
+                                  "category": "electronics"
+                              })
+    ad_id = ad_response.json()["id"]
+
+    response = client.post("/messages/",
+                           headers={"Authorization": f"Bearer {auth_token}"},
+                           json={
+                               "receiver_id": 2,
+                               "content": "Is this iPhone still available?",
+                               "advertisement_id": ad_id
+                           })
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["advertisement_id"] == ad_id
+
+
+def test_send_message_receiver_not_found(client, auth_token):
+    response = client.post("/messages/",
+                           headers={"Authorization": f"Bearer {auth_token}"},
+                           json={
+                               "receiver_id": 999,
+                               "content": "Hello",
+                               "advertisement_id": None
+                           })
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json()["detail"] == "Receiver not found"
+
+
+def test_send_message_unauthorized(client):
+    response = client.post("/messages/", json={
+        "receiver_id": 2,
+        "content": "Hello",
+        "advertisement_id": None
+    })
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_get_conversation_success(client, auth_token):
+    client.post("/users/register", json={
+        "username": "chat_partner",
+        "email": "partner@example.com",
+        "password": "password123"
+    })
+
+    client.post("/messages/",
+                headers={"Authorization": f"Bearer {auth_token}"},
+                json={
+                    "receiver_id": 2,
+                    "content": "First message",
+                    "advertisement_id": None
+                })
+
+    client.post("/messages/",
+                headers={"Authorization": f"Bearer {auth_token}"},
+                json={
+                    "receiver_id": 2,
+                    "content": "Second message",
+                    "advertisement_id": None
+                })
+
+    response = client.get("/messages/conversation/2",
+                          headers={"Authorization": f"Bearer {auth_token}"})
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert len(data) == 2
+    assert data[0]["content"] == "First message"
+    assert data[1]["content"] == "Second message"
+
+
+def test_get_conversation_unauthorized(client):
+    response = client.get("/messages/conversation/2")
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_get_empty_conversation(client, auth_token):
+    client.post("/users/register", json={
+        "username": "no_messages",
+        "email": "nomsg@example.com",
+        "password": "password123"
+    })
+
+    response = client.get("/messages/conversation/2",
+                          headers={"Authorization": f"Bearer {auth_token}"})
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == []


### PR DESCRIPTION
# Implement User-to-User Communication System

## Overview
Adds messaging functionality allowing users to communicate with each other about products, implementing the user story: "Users can communicate with other users about products."

## Changes Made

### Backend Components
- **Message Model**: New model with sender_id, receiver_id, advertisement_id, content, and timestamps
- **Message Schemas**: Pydantic schemas for MessageCreate and MessageResponse with validation
- **API Endpoints**: 
  - `POST /messages/` - Send message to another user
  - `GET /messages/conversation/{user_id}` - Retrieve conversation history

### Features
- Messages can be linked to specific advertisements or be general conversation
- Conversation history ordered chronologically
- Authentication required for all messaging operations
- Validation prevents messaging non-existent users

### Database Schema
- New `messages` table with foreign key relationships to users and advertisements
- Support for optional advertisement linking